### PR TITLE
Adding detectiong for the modern mac’s os.arch string

### DIFF
--- a/java/edu/cmu/cs/hcii/cogtool/util/OSUtils.java
+++ b/java/edu/cmu/cs/hcii/cogtool/util/OSUtils.java
@@ -199,7 +199,7 @@ public class OSUtils
         if (MACOSX) {
             String osArch = System.getProperty("os.arch");
 
-            if (osArch.toLowerCase().equals("i386")) {
+            if (osArch.toLowerCase().equals("i386") || osArch.toLowerCase().contains("x86")) {
                 return true;
             }
             else {


### PR DESCRIPTION
Modern mac as of macOS Catalina